### PR TITLE
fix: add missing CARGO_PKG_* env vars for build scripts

### DIFF
--- a/cargo_buildscript.bzl
+++ b/cargo_buildscript.bzl
@@ -129,6 +129,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
     env["OUT_DIR"] = out_dir.as_output()
     env["RUSTC"] = _make_rustc_shim(ctx, cwd)
     env["RUSTC_LINKER"] = "/bin/false"
+    env["RUSTDOC"] = cmd_args(toolchain_info.rustdoc, relative_to = cwd)
     env["RUST_BACKTRACE"] = "1"
     # Cargo sets this for build scripts, and some crates (e.g. tikv-jemalloc-sys)
     # expect it to be present. Defaulting is handled in the buildscript runner

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -253,6 +253,17 @@ def main() -> None:  # noqa: C901
     # NUM_JOBS is only set to available_parallelism() if not already present,
     # meaning an existing OS-level NUM_JOBS overrides cargo_buildscript.bzl config.
     env.setdefault("NUM_JOBS", str(available_parallelism()))
+    # Standard Cargo build script env vars that buck2 doesn't set by default.
+    # Required by crates like `built` that introspect the build environment.
+    # See: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+    if "PROFILE" not in env:
+        opt_level = env.get("OPT_LEVEL", "0")
+        env["PROFILE"] = "release" if opt_level not in ("0", "") else "debug"
+    env.setdefault("RUSTDOC", "rustdoc")
+    env.setdefault("CARGO_PKG_VERSION_MAJOR", "")
+    env.setdefault("CARGO_PKG_VERSION_MINOR", "")
+    env.setdefault("CARGO_PKG_VERSION_PATCH", "")
+    env.setdefault("CARGO_PKG_VERSION_PRE", "")
 
     target = env.get("TARGET")
     if target is None:

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -243,6 +243,17 @@ def main() -> None:  # noqa: C901
     env["OUT_DIR"] = os.path.abspath(out_dir)
 
     cwd = create_cwd(args.create_cwd, args.manifest_dir)
+
+    # Resolve path env vars to absolute paths, consistent with CARGO_MANIFEST_DIR
+    # and OUT_DIR.  manifest_parse.py emits these relative to the vendor directory
+    # but the synthetic cwd has a different parent-directory structure.
+    orig_manifest_dir = env.get("CARGO_MANIFEST_DIR")
+    if orig_manifest_dir:
+        for key in ("CARGO_PKG_README", "CARGO_PKG_LICENSE_FILE"):
+            val = env.get(key, "")
+            if val and not os.path.isabs(val):
+                env[key] = os.path.normpath(os.path.join(orig_manifest_dir, val))
+
     env["CARGO_MANIFEST_DIR"] = os.path.abspath(cwd)
     # *BUCKAL-ONLY* set manifest path
     env["CARGO_MANIFEST_PATH"] = os.path.abspath(cwd / "Cargo.toml")

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -244,16 +244,6 @@ def main() -> None:  # noqa: C901
 
     cwd = create_cwd(args.create_cwd, args.manifest_dir)
 
-    # Resolve path env vars to absolute paths, consistent with CARGO_MANIFEST_DIR
-    # and OUT_DIR.  manifest_parse.py emits these relative to the vendor directory
-    # but the synthetic cwd has a different parent-directory structure.
-    orig_manifest_dir = env.get("CARGO_MANIFEST_DIR")
-    if orig_manifest_dir:
-        for key in ("CARGO_PKG_README", "CARGO_PKG_LICENSE_FILE"):
-            val = env.get(key, "")
-            if val and not os.path.isabs(val):
-                env[key] = os.path.normpath(os.path.join(orig_manifest_dir, val))
-
     env["CARGO_MANIFEST_DIR"] = os.path.abspath(cwd)
     # *BUCKAL-ONLY* set manifest path
     env["CARGO_MANIFEST_PATH"] = os.path.abspath(cwd / "Cargo.toml")

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -253,17 +253,6 @@ def main() -> None:  # noqa: C901
     # NUM_JOBS is only set to available_parallelism() if not already present,
     # meaning an existing OS-level NUM_JOBS overrides cargo_buildscript.bzl config.
     env.setdefault("NUM_JOBS", str(available_parallelism()))
-    # Standard Cargo build script env vars that buck2 doesn't set by default.
-    # Required by crates like `built` that introspect the build environment.
-    # See: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-    if "PROFILE" not in env:
-        opt_level = env.get("OPT_LEVEL", "0")
-        env["PROFILE"] = "release" if opt_level not in ("0", "") else "debug"
-    env.setdefault("RUSTDOC", "rustdoc")
-    env.setdefault("CARGO_PKG_VERSION_MAJOR", "")
-    env.setdefault("CARGO_PKG_VERSION_MINOR", "")
-    env.setdefault("CARGO_PKG_VERSION_PATCH", "")
-    env.setdefault("CARGO_PKG_VERSION_PRE", "")
 
     target = env.get("TARGET")
     if target is None:

--- a/tool/manifest_parse.py
+++ b/tool/manifest_parse.py
@@ -68,6 +68,9 @@ def main() -> None:
         "homepage",
         "repository",
         "rust-version",
+        "license",
+        "license-file",
+        "readme",
     }
     for key in workspace_package_key:
         value = cargo_package.get(key)
@@ -94,6 +97,14 @@ def main() -> None:
     cargo_env["CARGO_PKG_HOMEPAGE"] = cargo_package.get("homepage", "")
     cargo_env["CARGO_PKG_REPOSITORY"] = cargo_package.get("repository", "")
     cargo_env["CARGO_PKG_RUST_VERSION"] = cargo_package.get("rust-version", "")
+    cargo_env["CARGO_PKG_LICENSE"] = cargo_package.get("license", "")
+    cargo_env["CARGO_PKG_LICENSE_FILE"] = cargo_package.get("license-file", "")
+    cargo_env["CARGO_PKG_README"] = cargo_package.get("readme", "")
+
+    # Coerce all values to strings (TOML booleans like `readme = true` are common)
+    for key in cargo_env:
+        if not isinstance(cargo_env[key], str):
+            cargo_env[key] = str(cargo_env[key])
 
     def to_ascii_escaped(value: str) -> str:
         return value.encode("ascii", "backslashreplace").decode("ascii")

--- a/tool/manifest_parse.py
+++ b/tool/manifest_parse.py
@@ -77,7 +77,13 @@ def main() -> None:
         value = cargo_package.get(key)
         if isinstance(value, dict) and value.get("workspace") is True:
             workspace_values = load_workspace_package()
-            cargo_package[key] = workspace_values.get(key)
+            workspace_value = workspace_values.get(key)
+            if workspace_value is None:
+                raise ValueError(
+                    f"Workspace inheritance requested for key '{key}' but "
+                    f"'[workspace.package]' does not define it"
+                )
+            cargo_package[key] = workspace_value
             inherited_from_workspace.add(key)
 
     # Parse semantic versioning
@@ -111,14 +117,23 @@ def main() -> None:
 
     license_file = cargo_package.get("license-file", "")
 
-    # When readme or license-file are inherited from the workspace, Cargo rebases
-    # the path relative to the member package directory.
-    if args.workspace:
-        workspace_root = args.workspace.parent
-        if readme and "readme" in inherited_from_workspace:
-            readme = os.path.relpath(workspace_root / readme, args.vendor)
-        if license_file and "license-file" in inherited_from_workspace:
-            license_file = os.path.relpath(workspace_root / license_file, args.vendor)
+    # Emit absolute paths for readme and license-file so build scripts can
+    # locate the files regardless of their (synthetic) working directory.
+    # For workspace-inherited values the path is relative to the workspace root;
+    # for member-local values it is relative to the vendor directory.
+    # NOTE: args.workspace must point to the real workspace Cargo.toml (not a
+    # buck-out copy) for inherited paths to resolve correctly — ensure the
+    # cargo-buckal export_file rule uses mode = "reference".
+    if readme:
+        if "readme" in inherited_from_workspace and args.workspace:
+            readme = str((args.workspace.parent / readme).resolve())
+        else:
+            readme = str((TOOL_CWD / args.vendor / readme).resolve())
+    if license_file:
+        if "license-file" in inherited_from_workspace and args.workspace:
+            license_file = str((args.workspace.parent / license_file).resolve())
+        else:
+            license_file = str((TOOL_CWD / args.vendor / license_file).resolve())
 
     cargo_env["CARGO_PKG_README"] = str(readme)
     cargo_env["CARGO_PKG_LICENSE_FILE"] = str(license_file)

--- a/tool/manifest_parse.py
+++ b/tool/manifest_parse.py
@@ -72,11 +72,13 @@ def main() -> None:
         "license-file",
         "readme",
     }
+    inherited_from_workspace = set()
     for key in workspace_package_key:
         value = cargo_package.get(key)
         if isinstance(value, dict) and value.get("workspace") is True:
             workspace_values = load_workspace_package()
-            cargo_package[key] = workspace_values.get(key)       
+            cargo_package[key] = workspace_values.get(key)
+            inherited_from_workspace.add(key)
 
     # Parse semantic versioning
     semver_pattern = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$")
@@ -98,13 +100,28 @@ def main() -> None:
     cargo_env["CARGO_PKG_REPOSITORY"] = cargo_package.get("repository", "")
     cargo_env["CARGO_PKG_RUST_VERSION"] = cargo_package.get("rust-version", "")
     cargo_env["CARGO_PKG_LICENSE"] = cargo_package.get("license", "")
-    cargo_env["CARGO_PKG_LICENSE_FILE"] = cargo_package.get("license-file", "")
-    cargo_env["CARGO_PKG_README"] = cargo_package.get("readme", "")
+    # Cargo interprets `readme = true` as "README.md" and `readme = false` as ""
+    # (see https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).
+    # A plain string is used as-is.
+    readme = cargo_package.get("readme", "")
+    if readme is True:
+        readme = "README.md"
+    elif readme is False:
+        readme = ""
 
-    # Coerce all values to strings (TOML booleans like `readme = true` are common)
-    for key in cargo_env:
-        if not isinstance(cargo_env[key], str):
-            cargo_env[key] = str(cargo_env[key])
+    license_file = cargo_package.get("license-file", "")
+
+    # When readme or license-file are inherited from the workspace, Cargo rebases
+    # the path relative to the member package directory.
+    if args.workspace:
+        workspace_root = args.workspace.parent
+        if readme and "readme" in inherited_from_workspace:
+            readme = os.path.relpath(workspace_root / readme, args.vendor)
+        if license_file and "license-file" in inherited_from_workspace:
+            license_file = os.path.relpath(workspace_root / license_file, args.vendor)
+
+    cargo_env["CARGO_PKG_README"] = str(readme)
+    cargo_env["CARGO_PKG_LICENSE_FILE"] = str(license_file)
 
     def to_ascii_escaped(value: str) -> str:
         return value.encode("ascii", "backslashreplace").decode("ascii")

--- a/wrapper.bzl
+++ b/wrapper.bzl
@@ -25,6 +25,11 @@ def _patch_buildscript_env(**kwargs):
         "buckal//config/mode:release": "0",
         "DEFAULT": "1",
     }))
+    env.update(PROFILE=select({
+        "buckal//config/mode:debug": "debug",
+        "buckal//config/mode:release": "release",
+        "DEFAULT": "debug",
+    }))
     return env
 
 def rust_binary(name, **kwargs):


### PR DESCRIPTION
Addresses #9 

manifest_parse.py: add CARGO_PKG_LICENSE, CARGO_PKG_LICENSE_FILE, and CARGO_PKG_README. Include license, license-file, and readme in the workspace-inheritable key set. Coerce non-string TOML values (e.g. readme = true) to strings before escaping.

buildscript_run.py: add PROFILE (derived from OPT_LEVEL), RUSTDOC, and fallback defaults for CARGO_PKG_VERSION_{MAJOR,MINOR,PATCH,PRE}.

Without these, crates whose build scripts read these standard Cargo env vars (e.g. the `built` crate) panic under Buck2.