### PR TITLE
fix-native-buildscript-linking

### DIFF
--- a/cargo_buildscript.bzl
+++ b/cargo_buildscript.bzl
@@ -177,7 +177,7 @@ def _make_cc_shim(ctx: AnalysisContext, name: str, cmd: cmd_args) -> cmd_args:
                     cmd_args(
                         cmd_args(internal_tools_info.from_any_dir, quote = "shell"),
                         '--cwd="${cc_original_dir}"',
-                        cmd_args(cmd, absolute_prefix = "${..}/", quote = "shell"),
+                        cmd_args("/usr/bin/env", cmd_args(cmd, absolute_prefix = "${..}/", quote = "shell")),
                         delimiter = " \\\n",
                     ),
                     # For linker, prepend every argument with `-Wl,`. Without this,
@@ -230,7 +230,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
     rust_toolchain_info = ctx.attrs._rust_toolchain[RustToolchainInfo]
 
     cwd = ctx.actions.declare_output("cwd", dir = True, has_content_based_path = True)
-    out_dir = ctx.actions.declare_output("OUT_DIR", dir = True, has_content_based_path = True)
+    out_dir = ctx.actions.declare_output("OUT_DIR", dir = True)
     rustc_flags = ctx.actions.declare_output("rustc_flags", has_content_based_path = True)
     # *BUCKAL-ONLY* metadata environment variables for *dependent* buildscript runners to consume
     metadata = ctx.actions.declare_output("METADATA")

--- a/cargo_buildscript.bzl
+++ b/cargo_buildscript.bzl
@@ -375,7 +375,12 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
         default_output = None,
         sub_targets = {
             "out_dir": [DefaultInfo(default_output = out_dir)],
-            "rustc_flags": [DefaultInfo(default_output = rustc_flags)],
+            "rustc_flags": [DefaultInfo(
+                default_output = rustc_flags,
+                # Keep the generated native artifacts as hidden inputs when this
+                # response file is consumed through $(location ...[rustc_flags]).
+                other_outputs = [out_dir],
+            )],
             "metadata": [DefaultInfo(default_output = metadata)],
         },
     )]

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -323,10 +323,8 @@ def main() -> None:  # noqa: C901
             if path.startswith(TOOL_CWD):
                 relative_path = path[len(TOOL_CWD) :]
                 flags += f"-L{kind}{relative_path}\n"
-            elif not os.path.isabs(path):
-                flags += f"-L{kind}{path}\n"
             else:
-                # Disregard absolute link search paths outside the workspace.
+                # Disregard link-search paths that cannot be resolved from the project root.
                 pass
             continue
         # *BUCKAL-ONLY* metadata processing

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -322,9 +322,11 @@ def main() -> None:  # noqa: C901
             path = cargo_rustc_link_search_match.group(2)
             if path.startswith(TOOL_CWD):
                 relative_path = path[len(TOOL_CWD) :]
-                flags += f"-L{kind}$(abspath {relative_path})\n"
+                flags += f"-L{kind}{relative_path}\n"
+            elif not os.path.isabs(path):
+                flags += f"-L{kind}{path}\n"
             else:
-                # Disregard link search not located within the build script's out dir.
+                # Disregard absolute link search paths outside the workspace.
                 pass
             continue
         # *BUCKAL-ONLY* metadata processing


### PR DESCRIPTION
## Summary

Fix native Cargo build-script integration for system GCC toolchains and content-addressed Buck outputs.

- Resolve Linux system tools through `/usr/bin/env` in generated sh shims.
- Avoid passing Clang-only `--ld-path` to `CC` and `CXX`.
- Keep build-script `OUT_DIR` at a stable Buck output path.
- Preserve relative `cargo:rustc-link-search` values and emit direct Rust `-L` arguments.

## Root cause

`libsqlite3-sys` generated `libsqlite3.a`, but its build-script link search path was emitted as a literal `$(abspath ...)` inside an args file and pointed at a content-addressed output path that Rust actions could not resolve.

## Validation

WSL with Buck2 2026-04-15:

```text
buck2 build //project/distribution:distribution
BUILD SUCCEEDED
```