### PR TITLE
fix: copy buildscript cwd contents instead of symlinks

### DIFF
--- a/cargo_buildscript.bzl
+++ b/cargo_buildscript.bzl
@@ -330,6 +330,8 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
             sanitizer_flags,
         ),
     )
+    # Keep C/C++ compiler link phases routed through the LD shim so non-default
+    # linkers and linker flags stay consistent with env[LD] selection.
     compiler_linker = (
         cmd_args(env["LD"], parent = 1, format = "-B{}")
         if ctx.attrs._exec_os_type[OsLookup].script == ScriptLanguage("sh")

--- a/tool/buildscript_run.py
+++ b/tool/buildscript_run.py
@@ -13,6 +13,7 @@ Run a crate's Cargo buildscript.
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 import json
@@ -73,8 +74,14 @@ def cfg_env(rustc_cfg: Path) -> Dict[str, str]:
 
 
 def create_cwd(path: Path, manifest_dir: Path) -> Path:
-    """Create a directory with most of the same contents as manifest_dir, but
+    """Create a directory with a copy of most of manifest_dir, but
     excluding Rustup's rust-toolchain.toml configuration file.
+
+    Build-script outputs can be collected through a remote or FUSE-backed
+    filesystem.  A tree of relative symlinks is not reliable there: the
+    symlink entry can be observed before its target is materialized, causing
+    output collection to fail.  Use real copies so the declared cwd output is
+    self-contained and stable.
 
     Keeping rust-toolchain.toml goes wrong in the situation that all of the
     following happen:
@@ -121,9 +128,16 @@ def create_cwd(path: Path, manifest_dir: Path) -> Path:
 
     for dir_entry in manifest_dir.iterdir():
         if dir_entry.name not in ["rust-toolchain", "rust-toolchain.toml"]:
-            link = path.joinpath(dir_entry.name)
-            link.unlink(missing_ok=True)
-            link.symlink_to(os.path.relpath(dir_entry, path))
+            destination = path.joinpath(dir_entry.name)
+            if destination.is_dir() and not destination.is_symlink():
+                shutil.rmtree(destination)
+            else:
+                destination.unlink(missing_ok=True)
+
+            if dir_entry.is_dir():
+                shutil.copytree(dir_entry, destination, symlinks=False)
+            else:
+                shutil.copy2(dir_entry, destination, follow_symlinks=True)
 
     return path
 


### PR DESCRIPTION
## What changed

- Change /tool/buildscript_run.py: create_cwd now copies manifest directories/files into the buildscript cwd and avoids symlink-based relative references.
- Keep existing exclusions for rust-toolchain / rust-toolchain.toml.
- Add comment explaining that copied outputs avoid symlink race on remote/FUSE-backed output collection.

## Why

Buck2 output collection can observe symlink entries before their targets exist on remote/FUSE filesystems, causing ead_link failures. Copying outputs makes the cwd artifact self-contained and more deterministic.

## Validation

- py_compile and focused local cwd/FS smoke checks.
