### PR TITLE
fix: isolate buildscript cwd outputs

### DIFF
--- a/cargo_buildscript.bzl
+++ b/cargo_buildscript.bzl
@@ -235,7 +235,10 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
     cxx_toolchain_info = ctx.attrs._cxx_toolchain[CxxToolchainInfo]
     rust_toolchain_info = ctx.attrs._rust_toolchain[RustToolchainInfo]
 
-    cwd = ctx.actions.declare_output("cwd", dir = True, has_content_based_path = True)
+    # The build script mutates this working directory. Keep it on the
+    # configured-target path so concurrent configurations do not share the
+    # content-based output staging directory while Buck snapshots it.
+    cwd = ctx.actions.declare_output("cwd", dir = True)
     out_dir = ctx.actions.declare_output("OUT_DIR", dir = True)
     rustc_flags = ctx.actions.declare_output("rustc_flags", has_content_based_path = True)
     # *BUCKAL-ONLY* metadata environment variables for *dependent* buildscript runners to consume


### PR DESCRIPTION
## Summary

- keep the mutable Cargo build-script working directory on the configured-target output path
- avoid content-based staging and materialization for `cwd`
- leave `OUT_DIR` tracking and content-based `rustc_flags` behavior unchanged

## Root cause

`cwd` was declared with `has_content_based_path = True`. Buck therefore ran build scripts against an `output_artifacts/cwd` staging path and materialized the directory to its content-addressed destination afterward. Under concurrent configured build-script actions on ScorpioFS, that mutable staging directory could be observed or modified while another operation was cleaning, copying, or snapshotting it.

This produced both observed failure modes:

- `shutil.rmtree(.../output_artifacts/cwd/...)` failing with `ENOTEMPTY`
- Buck materialization finding a previously enumerated file such as `.gitattributes` missing with `ENOENT`

A build-script working directory is mutable and does not need a content-based final path. Using the normal configured output path includes the configuration hash and removes the shared staging/materialization step.

## Impact

Cargo build scripts retain a private writable manifest copy, while concurrent configurations no longer contend on the same temporary `cwd`. Native artifacts in `OUT_DIR` remain explicitly tracked through the `rustc_flags` subtarget.

## Validation

- reproduced the original race locally on a ScorpioFS Antares parent-monorepo mount while building `root//project/libruntime:libruntime`; the baseline failed in `serde_core:build-script-run` with `ENOTEMPTY`
- built fresh `[rustc_flags]` subtargets for `serde_core 1.0.228`, `thiserror 1.0.69`, and the reported `prettyplease 0.2.37` in a new Buck2 isolation: `BUILD SUCCEEDED`
- completed a clean ScorpioFS-backed build of `root//project/libruntime:libruntime`: `BUILD SUCCEEDED`, 3,239 local commands, 0% cache hits
- verified generated build-script commands now use configuration-qualified `.../art/root/<config-hash>/.../cwd` paths instead of shared `.../output_artifacts/cwd` paths
